### PR TITLE
fix: Querying & API

### DIFF
--- a/Console/src/scenes/domains/index.js
+++ b/Console/src/scenes/domains/index.js
@@ -55,8 +55,10 @@ const Domains = () => {
       }));
 
       setResults(mappedResults);
+      setLoading(false);
     } catch (err) {
             if (err.response && err.response.status === 400) {
+            setLoading(false);
               setResults([]);
             }
           }
@@ -159,7 +161,7 @@ const Domains = () => {
                   sx={{ mr: '10px' }}
                 />
             <TextField
-              label="Country"
+              label="COUNTRY"
               variant="outlined"
               value={filters['country.name']}
               onChange={(e) => handleFilterChange('country.name', e.target.value)}

--- a/Console/src/scenes/scans/index.js
+++ b/Console/src/scenes/scans/index.js
@@ -201,38 +201,38 @@ const buildQueryParams = () => {
             sx={{ mr: '10px' }}
           />
             <TextField
-              label="ASN Name"
+              label="ASN NAME"
               variant="outlined"
-              value={filters['server.asn.asn_org']}
-              onChange={(e) => handleFilterChange('server.asn.asn_org', e.target.value)}
+              value={filters['server.asn.name']}
+              onChange={(e) => handleFilterChange('server.asn.name', e.target.value)}
               sx={{ mr: '10px' }}
             />
           <TextField
-            label="Country"
+            label="COUNTRY"
             variant="outlined"
-            value={filters['server.country.country']}
-            onChange={(e) => handleFilterChange('server.country.country', e.target.value)}
+            value={filters['server.country.name']}
+            onChange={(e) => handleFilterChange('server.country.name', e.target.value)}
             sx={{ mr: '10px' }}
           />
           <TextField
             label="DOMAIN"
             variant="outlined"
-            value={filters['domain.domain']}
-            onChange={(e) => handleFilterChange('domain.domain', e.target.value)}
+            value={filters['domain.name']}
+            onChange={(e) => handleFilterChange('domain.name', e.target.value)}
             sx={{ mr: '10px' }}
           />
             <TextField
-              label="Server"
+              label="SERVER"
               variant="outlined"
               value={filters['server.server']}
               onChange={(e) => handleFilterChange('server.server', e.target.value)}
               sx={{ mr: '10px' }}
             />
           <TextField
-          label="Technology"
+          label="TECHNOLOGY"
           variant="outlined"
-          value={filters['technology.technology']}
-          onChange={(e) => handleFilterChange('technology.technology', e.target.value)}
+          value={filters['technology.name']}
+          onChange={(e) => handleFilterChange('technology.name', e.target.value)}
           sx={{ mr: '10px' }}
         />
         </Box>

--- a/Console/src/scenes/servers/index.js
+++ b/Console/src/scenes/servers/index.js
@@ -56,10 +56,13 @@ headers: {
       }));
 
       setResults(mappedResults);
+      setLoading(false);
     } catch (err) {
-          console.log('error')
-                   setLoading(false);
-          }
+                  if (err.response && err.response.status === 400) {
+                  setLoading(false);
+                    setResults([]);
+                  }
+                }
   };
 
   useEffect(() => {
@@ -106,7 +109,7 @@ headers: {
         </Box>
         <Box sx={{ display: 'flex', mb: '20px' }}>
           <TextField
-            label="Server"
+            label="SERVER NAME"
             variant="outlined"
             value={filters.server}
             onChange={(e) => handleFilterChange('server', e.target.value)}
@@ -120,21 +123,21 @@ headers: {
             sx={{ mr: '10px' }}
           />
           <TextField
-            label="ASN"
+            label="ASN NAME"
             variant="outlined"
-            value={filters['asn.asn_org']}
-            onChange={(e) => handleFilterChange('asn.asn_org', e.target.value)}
+            value={filters['asn.name']}
+            onChange={(e) => handleFilterChange('asn.name', e.target.value)}
             sx={{ mr: '10px' }}
           />
           <TextField
-            label="Country"
+            label="COUNTRY"
             variant="outlined"
-            value={filters['country.country']}
-            onChange={(e) => handleFilterChange('country.country', e.target.value)}
+            value={filters['country.name']}
+            onChange={(e) => handleFilterChange('country.name', e.target.value)}
             sx={{ mr: '10px' }}
           />
           <TextField
-            label="Domain"
+            label="DOMAIN"
             variant="outlined"
             value={filters.domain}
             onChange={(e) => handleFilterChange('domain', e.target.value)}


### PR DESCRIPTION
- API, incorrect reply for /domains was a 200 when no results, caused incorrect frontend update logic
- API, incorrect reply for /servers was a 200 when no results, caused incorrect frontend update logic
- Frontend change to handle above, 400 returned, result tables is cleared
- setLoading(false) domains page, loading wheel continued when results returned
- setLoading(false) servers page, loading wheel continued when results returned